### PR TITLE
[Feature] Add new API endpoint to create certificate on behalf of user

### DIFF
--- a/src/certificates/dto/create-certificate-on-behalf-of.dto.ts
+++ b/src/certificates/dto/create-certificate-on-behalf-of.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+import { CreateCertificateDto } from './create-certificate.dto';
+
+export class CreateCertificateOnBehalfOfDto extends CreateCertificateDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  userId: number;
+}

--- a/src/certificates/dto/index.ts
+++ b/src/certificates/dto/index.ts
@@ -4,3 +4,4 @@ export * from './create-certificate-upload-url.dto';
 export * from './certificate-upload-url-response.dto';
 export * from './certificate-response.dto';
 export * from './search-certificates-query.dto';
+export * from './create-certificate-on-behalf-of.dto';


### PR DESCRIPTION
## Description
This PR includes a new API endpoint `/certificates/create-on-behalf-of` which enables an admin to create a certificate on behalf of a user

## Change summary
- Created a new DTO `CreateCertificateOnBehalfOf`
- Created a new API endpoint `/certificates/create-on-behalf-of`

## Checklist
- [x] I have performed a self-review of my code
- [x] I tested locally
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New package or package update introduced
